### PR TITLE
Refactors doubles to use floats instead

### DIFF
--- a/src/data_tools/base_data.h
+++ b/src/data_tools/base_data.h
@@ -44,7 +44,7 @@ class BaseData {
 
             Diagnostics get() {
                 return Diagnostics{
-                    std::accumulate(sparsity.begin(), sparsity.end(), 0.0) / sparsity.size(),
+                    std::accumulate(sparsity.begin(), sparsity.end(), (float)0.0) / sparsity.size(),
                     totalNonEmptyCells
                 };
             }

--- a/src/data_tools/base_data.h
+++ b/src/data_tools/base_data.h
@@ -6,7 +6,7 @@
 #include <bits/stdc++.h> 
 
 struct diagnostics {
-    double sparsity;
+    float sparsity;
     size_t numberOfNonEmptyCells;
 } typedef Diagnostics;
 
@@ -24,7 +24,7 @@ class BaseData {
 
         class DiagnosticsVisitor : public ReturningDataRowVisitor<Diagnostics> {
             private:
-            std::vector<double> sparsity;
+            std::vector<float> sparsity;
             size_t totalNonEmptyCells;
             size_t i;
             
@@ -32,13 +32,13 @@ class BaseData {
             DiagnosticsVisitor(size_t rows) 
             : sparsity(rows), i(0), totalNonEmptyCells(0) {}
 
-            void visitDenseDataRow(const std::vector<double>& data) {
+            void visitDenseDataRow(const std::vector<float>& data) {
                 sparsity[i++] = 0.0;
                 totalNonEmptyCells += data.size();
             }
 
-            void visitSparseDataRow(const std::map<size_t, double>& data, size_t totalColumns) {
-                sparsity[i++] = (double)((double)(totalColumns - data.size()) / (double)totalColumns);
+            void visitSparseDataRow(const std::map<size_t, float>& data, size_t totalColumns) {
+                sparsity[i++] = (float)((float)(totalColumns - data.size()) / (float)totalColumns);
                 totalNonEmptyCells += data.size();
             }
 
@@ -88,9 +88,9 @@ class FullyLoadedData : public BaseData {
         return std::unique_ptr<FullyLoadedData>(new FullyLoadedData(move(data), columns));
     }
 
-    static std::unique_ptr<FullyLoadedData> load(std::vector<std::vector<double>> raw) {
+    static std::unique_ptr<FullyLoadedData> load(std::vector<std::vector<float>> raw) {
         std::vector<std::unique_ptr<DataRow>> data;
-        for (std::vector<double> v : raw) {
+        for (std::vector<float> v : raw) {
             data.push_back(std::unique_ptr<DataRow>(new DenseDataRow(move(v))));
         }
 

--- a/src/data_tools/data_row.h
+++ b/src/data_tools/data_row.h
@@ -8,7 +8,7 @@ static const std::string DELIMETER = ",";
 class DataRow {
     public:
     virtual size_t size() const = 0;
-    virtual double dotProduct(const DataRow& dataRow) const = 0;
+    virtual float dotProduct(const DataRow& dataRow) const = 0;
     virtual void voidVisit(DataRowVisitor &visitor) const = 0;
 
     template <typename T>
@@ -20,20 +20,20 @@ class DataRow {
 
 class DenseDataRow : public DataRow {
     private:
-    std::vector<double> data;
+    std::vector<float> data;
 
     DenseDataRow(const DenseDataRow &);
 
     public:
     DenseDataRow() {}
     
-    DenseDataRow(std::vector<double> input) : data(move(input)) {}
+    DenseDataRow(std::vector<float> input) : data(move(input)) {}
 
-    static std::unique_ptr<DataRow> of(std::vector<double> data) {
+    static std::unique_ptr<DataRow> of(std::vector<float> data) {
         return std::unique_ptr<DataRow>(new DenseDataRow(move(data)));
     }
 
-    void push_back(double val) {
+    void push_back(float val) {
         this->data.push_back(val);
     }
 
@@ -41,7 +41,7 @@ class DenseDataRow : public DataRow {
         return this->data.size();
     }
 
-    double dotProduct(const DataRow& dataRow) const {
+    float dotProduct(const DataRow& dataRow) const {
         DenseDotProductDataRowVisitor visitor(this->data);
         return dataRow.visit(visitor);
     }
@@ -53,13 +53,13 @@ class DenseDataRow : public DataRow {
 
 class SparseDataRow : public DataRow {
     private:
-    const std::map<size_t, double> rowToValue;
+    const std::map<size_t, float> rowToValue;
     const size_t totalColumns;
 
     SparseDataRow(const SparseDataRow &);
 
     public:
-    SparseDataRow(std::map<size_t, double> map, size_t totalColumns) : 
+    SparseDataRow(std::map<size_t, float> map, size_t totalColumns) : 
         rowToValue(move(map)), 
         totalColumns(totalColumns) 
     {}
@@ -68,7 +68,7 @@ class SparseDataRow : public DataRow {
         return this->totalColumns;
     }
 
-    double dotProduct(const DataRow& dataRow) const {
+    float dotProduct(const DataRow& dataRow) const {
         SparseDotProductDataRowVisitor visitor(this->rowToValue);
         return dataRow.visit(visitor);
     }

--- a/src/data_tools/data_row_factory.h
+++ b/src/data_tools/data_row_factory.h
@@ -9,7 +9,7 @@
 
 class RandomNumberGenerator {
     public:
-    virtual double getNumber() = 0;
+    virtual float getNumber() = 0;
     virtual void skipNextElements(size_t elementsToSkip) = 0;
 };
 
@@ -23,7 +23,7 @@ class AlwaysOneGenerator : public RandomNumberGenerator {
         // no-op
     }
 
-    double getNumber() {
+    float getNumber() {
         return 1;
     }
 };
@@ -31,17 +31,17 @@ class AlwaysOneGenerator : public RandomNumberGenerator {
 class NormalRandomNumberGenerator : public RandomNumberGenerator {
     private:
     std::default_random_engine eng;
-    std::normal_distribution<double> distribution;
+    std::normal_distribution<float> distribution;
 
     public:
     NormalRandomNumberGenerator(
         std::default_random_engine eng, 
-        std::normal_distribution<double> distribution
+        std::normal_distribution<float> distribution
     ) : eng(move(eng)), distribution(move(distribution)) {}
 
     static std::unique_ptr<RandomNumberGenerator> create(const long unsigned int seed) {
         std::default_random_engine eng(seed);
-        std::normal_distribution<double> distribution;
+        std::normal_distribution<float> distribution;
         return std::unique_ptr<RandomNumberGenerator>(new NormalRandomNumberGenerator(move(eng), move(distribution)));
     }
     
@@ -49,7 +49,7 @@ class NormalRandomNumberGenerator : public RandomNumberGenerator {
         eng.discard(elementsToSkip);
     }
 
-    double getNumber() {
+    float getNumber() {
         return distribution(eng);
     }
 };
@@ -57,17 +57,17 @@ class NormalRandomNumberGenerator : public RandomNumberGenerator {
 class UniformRandomNumberGenerator : public RandomNumberGenerator {
     private:
     std::default_random_engine eng;
-    std::uniform_real_distribution<double> distribution;
+    std::uniform_real_distribution<float> distribution;
 
     public:
     UniformRandomNumberGenerator(
         std::default_random_engine eng, 
-        std::uniform_real_distribution<double> distribution
+        std::uniform_real_distribution<float> distribution
     ) : eng(move(eng)), distribution(move(distribution)) {}
 
     static std::unique_ptr<RandomNumberGenerator> create(const long unsigned int seed) {
         std::default_random_engine eng(seed);
-        std::uniform_real_distribution<double> distribution(0.0, 1.0);
+        std::uniform_real_distribution<float> distribution(0.0, 1.0);
         return std::unique_ptr<RandomNumberGenerator>(new UniformRandomNumberGenerator(move(eng), move(distribution)));
     }
     
@@ -75,7 +75,7 @@ class UniformRandomNumberGenerator : public RandomNumberGenerator {
         eng.discard(elementsToSkip);
     }
 
-    double getNumber() {
+    float getNumber() {
         return distribution(eng);
     }
 
@@ -157,7 +157,7 @@ class GeneratedSparseLineFactory : public LineFactory {
     private:
     const size_t numRows;
     const size_t numColumns;
-    const double sparsity;
+    const float sparsity;
     std::unique_ptr<RandomNumberGenerator> edgeValueRng;
     std::unique_ptr<RandomNumberGenerator> includeEdgeRng;
 
@@ -168,7 +168,7 @@ class GeneratedSparseLineFactory : public LineFactory {
     GeneratedSparseLineFactory(
         const size_t numRows,
         const size_t numColumns,
-        const double sparsity,
+        const float sparsity,
         std::unique_ptr<RandomNumberGenerator> edgeValueRng,
         std::unique_ptr<RandomNumberGenerator> includeEdgeRng 
     ) : 
@@ -191,7 +191,7 @@ class GeneratedSparseLineFactory : public LineFactory {
             return std::nullopt;
         }
 
-        double edgeValue = this->edgeValueRng->getNumber();
+        float edgeValue = this->edgeValueRng->getNumber();
 
         while (this->includeEdgeRng->getNumber() < this->sparsity) {
             this->currentColumn++;
@@ -222,8 +222,8 @@ class GeneratedSparseLineFactory : public LineFactory {
 class DataRowFactory {
     public:
     virtual std::unique_ptr<DataRow> maybeGet(LineFactory &source) = 0;
-    virtual std::unique_ptr<DataRow> getFromNaiveBinary(std::vector<double> binary) const = 0;
-    virtual std::unique_ptr<DataRow> getFromBinary(std::vector<double> binary) const = 0;
+    virtual std::unique_ptr<DataRow> getFromNaiveBinary(std::vector<float> binary) const = 0;
+    virtual std::unique_ptr<DataRow> getFromBinary(std::vector<float> binary) const = 0;
     virtual void skipNext(LineFactory &source) = 0;
 };
 
@@ -235,7 +235,7 @@ class DenseDataRowFactory : public DataRowFactory {
             return nullptr;
         }
         
-        std::vector<double> result;
+        std::vector<float> result;
 
         char *token;
         char *rest = data.value().data();
@@ -249,11 +249,11 @@ class DenseDataRowFactory : public DataRowFactory {
         source.skipNext();
     }
 
-    std::unique_ptr<DataRow> getFromNaiveBinary(std::vector<double> binary) const {
+    std::unique_ptr<DataRow> getFromNaiveBinary(std::vector<float> binary) const {
         return std::unique_ptr<DataRow>(new DenseDataRow(move(binary)));
     }
 
-    std::unique_ptr<DataRow> getFromBinary(std::vector<double> binary) const {
+    std::unique_ptr<DataRow> getFromBinary(std::vector<float> binary) const {
         return this->getFromNaiveBinary(move(binary));
     }
 };
@@ -267,7 +267,7 @@ class SparseDataRowFactory : public DataRowFactory {
 
     long expectedRow;
     long currentRow;
-    double value = 1.0; 
+    float value = 1.0; 
     long to;
     bool hasData;
 
@@ -283,7 +283,7 @@ class SparseDataRowFactory : public DataRowFactory {
     }
 
     std::unique_ptr<DataRow> maybeGet(LineFactory &source) {
-        std::map<size_t, double> result;
+        std::map<size_t, float> result;
 
         while (true) {
             if (this->hasData) {
@@ -308,7 +308,7 @@ class SparseDataRowFactory : public DataRowFactory {
             this->hasData = false;
 
             std::istringstream stream(line.value().data());
-            double number;
+            float number;
             size_t totalSeen = 0;
 
             // The expected format is a two ints a line, and 
@@ -339,8 +339,8 @@ class SparseDataRowFactory : public DataRowFactory {
         } 
     }
 
-    std::unique_ptr<DataRow> getFromNaiveBinary(std::vector<double> binary) const {
-        std::map<size_t, double> res;
+    std::unique_ptr<DataRow> getFromNaiveBinary(std::vector<float> binary) const {
+        std::map<size_t, float> res;
         for (size_t i = 0; i < binary.size(); i++) {
             if (binary[i] != 0) {
                 res.insert({static_cast<size_t>(i), binary[i]});
@@ -350,8 +350,8 @@ class SparseDataRowFactory : public DataRowFactory {
         return std::unique_ptr<DataRow>(new SparseDataRow(move(res), this->totalColumns));    
     }
 
-    std::unique_ptr<DataRow> getFromBinary(std::vector<double> binary) const {
-        std::map<size_t, double> res;
+    std::unique_ptr<DataRow> getFromBinary(std::vector<float> binary) const {
+        std::map<size_t, float> res;
 
         if (binary.size() % 2 != 0) {
             throw std::invalid_argument("ERROR: Received an input that is not divisible by two. This will likely cause a seg fault");

--- a/src/data_tools/data_row_visitor.h
+++ b/src/data_tools/data_row_visitor.h
@@ -3,8 +3,8 @@
 
 class DataRowVisitor {
     public:
-    virtual void visitDenseDataRow(const std::vector<double>& data) = 0;
-    virtual void visitSparseDataRow(const std::map<size_t, double>& data, size_t totalColumns) = 0;
+    virtual void visitDenseDataRow(const std::vector<float>& data) = 0;
+    virtual void visitSparseDataRow(const std::map<size_t, float>& data, size_t totalColumns) = 0;
 };
 
 template <typename T>

--- a/src/data_tools/dot_product_visitor.h
+++ b/src/data_tools/dot_product_visitor.h
@@ -1,17 +1,17 @@
 #include <optional>
 #include <iostream>
 
-class DenseDotProductDataRowVisitor : public ReturningDataRowVisitor<double> {
+class DenseDotProductDataRowVisitor : public ReturningDataRowVisitor<float> {
     private:
-    std::optional<double> result;
-    const std::vector<double>& base;
+    std::optional<float> result;
+    const std::vector<float>& base;
 
     public:
-    DenseDotProductDataRowVisitor(const std::vector<double>& input) 
+    DenseDotProductDataRowVisitor(const std::vector<float>& input) 
     : base(input), result(std::nullopt) {}
 
-    void visitDenseDataRow(const std::vector<double>& data) {
-        double dotProduct = 0;
+    void visitDenseDataRow(const std::vector<float>& data) {
+        float dotProduct = 0;
         for (size_t i = 0; i < this->base.size() && i < data.size(); i++) {
             dotProduct += this->base[i] * data[i];
         }
@@ -19,8 +19,8 @@ class DenseDotProductDataRowVisitor : public ReturningDataRowVisitor<double> {
         this->result = dotProduct;
     }
 
-    void visitSparseDataRow(const std::map<size_t, double>& data, size_t _totalColumns) {
-        double dotProduct = 0;
+    void visitSparseDataRow(const std::map<size_t, float>& data, size_t _totalColumns) {
+        float dotProduct = 0;
         for (const auto & p : data) {
             dotProduct += this->base[p.first] * p.second;
         }
@@ -28,22 +28,22 @@ class DenseDotProductDataRowVisitor : public ReturningDataRowVisitor<double> {
         this->result = dotProduct;
     }
 
-    double get() {
+    float get() {
         return this->result.value();
     }
 };
 
-class SparseDotProductDataRowVisitor : public ReturningDataRowVisitor<double> {
+class SparseDotProductDataRowVisitor : public ReturningDataRowVisitor<float> {
     private:
-    std::optional<double> result;
-    const std::map<size_t, double>& base;
+    std::optional<float> result;
+    const std::map<size_t, float>& base;
 
     public:
-    SparseDotProductDataRowVisitor(const std::map<size_t, double>& input) 
+    SparseDotProductDataRowVisitor(const std::map<size_t, float>& input) 
     : base(input), result(std::nullopt) {}
 
-    void visitDenseDataRow(const std::vector<double>& data) {
-        double dotProduct = 0;
+    void visitDenseDataRow(const std::vector<float>& data) {
+        float dotProduct = 0;
         for (const auto & p : this->base) {
             dotProduct += data[p.first] * p.second;
         }
@@ -51,8 +51,8 @@ class SparseDotProductDataRowVisitor : public ReturningDataRowVisitor<double> {
         this->result = dotProduct;
     }
 
-    void visitSparseDataRow(const std::map<size_t, double>& data, size_t _totalColumns) {
-        double dotProduct = 0;
+    void visitSparseDataRow(const std::map<size_t, float>& data, size_t _totalColumns) {
+        float dotProduct = 0;
 
         auto baseIterator = this->base.begin();
         auto dataIterator = data.begin();
@@ -71,7 +71,7 @@ class SparseDotProductDataRowVisitor : public ReturningDataRowVisitor<double> {
         this->result = dotProduct;
     }
 
-    double get() {
+    float get() {
         return this->result.value();
     }
 };

--- a/src/data_tools/tests.h
+++ b/src/data_tools/tests.h
@@ -17,17 +17,17 @@ class DataRowVerifier : public DataRowVisitor {
     public:
     DataRowVerifier(size_t expectedRow) : expectedRow(expectedRow) {}
 
-    void visitDenseDataRow(const std::vector<double>& data) {
+    void visitDenseDataRow(const std::vector<float>& data) {
         CHECK(data == DENSE_DATA[this->expectedRow]);
     }
 
-    void visitSparseDataRow(const std::map<size_t, double>& data, size_t totalColumns) {
+    void visitSparseDataRow(const std::map<size_t, float>& data, size_t totalColumns) {
         CHECK(data == SPARSE_DATA_AS_MAP[expectedRow]);
         CHECK(totalColumns == SPARSE_DATA_TOTAL_COLUMNS);
     }
 };
 
-static std::string rowToString(const std::vector<double> &row) {
+static std::string rowToString(const std::vector<float> &row) {
     std::ostringstream outputStream;
     for (const auto & v : row) {
         outputStream << v << ",";
@@ -37,7 +37,7 @@ static std::string rowToString(const std::vector<double> &row) {
     return output;
 }
 
-static std::string matrixToString(const std::vector<std::vector<double>> &data) {
+static std::string matrixToString(const std::vector<std::vector<float>> &data) {
     std::string output = "";
     for (const auto & row : data) {
         output += rowToString(row);
@@ -91,7 +91,7 @@ static void verifyData(
     }
 }
 
-static void DEBUG_printData(const std::vector<std::vector<double>> &data) {
+static void DEBUG_printData(const std::vector<std::vector<float>> &data) {
     for (const auto & d : data) {
         for (const auto & v : d) {
             std::cout << v << ", ";
@@ -205,7 +205,7 @@ TEST_CASE("Testing dense binary to data row conversion") {
     
         // Test data row to binary
         ToBinaryVisitor toBinary;
-        std::vector<double> newBinary(row->visit(toBinary));
+        std::vector<float> newBinary(row->visit(toBinary));
         
         // Verify old and new binaries are equivalent
         CHECK(newBinary == DENSE_DATA[i]);
@@ -218,7 +218,7 @@ TEST_CASE("Testing sparse binary to data row conversion") {
     
         // Test data row to binary
         ToBinaryVisitor toBinary;
-        std::vector<double> newBinary(row->visit(toBinary));
+        std::vector<float> newBinary(row->visit(toBinary));
     
         // Try loading from binary
         SparseDataRowFactory factory(SPARSE_DATA_TOTAL_COLUMNS);
@@ -235,19 +235,19 @@ TEST_CASE("Testing dot products") {
             std::unique_ptr<DataRow> sparseRow(new SparseDataRow(SPARSE_DATA_AS_MAP[s], SPARSE_DATA_TOTAL_COLUMNS));
 
             // dense to dense
-            double denseToDense = denseRow->dotProduct(*denseRow);
+            float denseToDense = denseRow->dotProduct(*denseRow);
             CHECK(denseToDense > 0);
             
             // dense to sparse
-            double denseToSparse = denseRow->dotProduct(*sparseRow);
+            float denseToSparse = denseRow->dotProduct(*sparseRow);
             CHECK(denseToSparse > 0);
 
             // sparse to dense
-            double sparseToDense = sparseRow->dotProduct(*denseRow);
+            float sparseToDense = sparseRow->dotProduct(*denseRow);
             CHECK(sparseToDense > 0);
 
             // sparse to sparse
-            double sparseToSparse = sparseRow->dotProduct(*sparseRow);
+            float sparseToSparse = sparseRow->dotProduct(*sparseRow);
             CHECK(sparseToSparse > 0);
         }
     }

--- a/src/data_tools/to_binary_visitor.h
+++ b/src/data_tools/to_binary_visitor.h
@@ -1,21 +1,21 @@
 
-class ToBinaryVisitor : public ReturningDataRowVisitor<std::vector<double>> {
+class ToBinaryVisitor : public ReturningDataRowVisitor<std::vector<float>> {
     private:
-    std::vector<double> binary;
+    std::vector<float> binary;
 
     public:
-    void visitDenseDataRow(const std::vector<double>& data) {
+    void visitDenseDataRow(const std::vector<float>& data) {
         binary = data;
     }
 
-    void visitSparseDataRow(const std::map<size_t, double>& data, size_t totalColumns) {
+    void visitSparseDataRow(const std::map<size_t, float>& data, size_t totalColumns) {
         for (const auto & p : data) {
-            binary.push_back(static_cast<double>(p.first));
+            binary.push_back(static_cast<float>(p.first));
             binary.push_back(p.second);
         }
     }
 
-    std::vector<double> get() {
+    std::vector<float> get() {
         return move(binary);
     }
 };

--- a/src/find_approximation_set.cpp
+++ b/src/find_approximation_set.cpp
@@ -26,6 +26,7 @@ int main(int argc, char** argv) {
     CLI11_PARSE(app, argc, argv);
 
     Timers timers;
+    
 
     timers.loadingDatasetTime.startTimer();
 
@@ -49,10 +50,12 @@ int main(int argc, char** argv) {
     timers.loadingDatasetTime.stopTimer();
 
     timers.totalCalculationTime.startTimer();
+    
     std::unique_ptr<SubsetCalculator> calculator(Orchestrator::getCalculator(appData));
+    
     std::unique_ptr<Subset> solution = calculator->getApproximationSet(*data.get(), appData.outputSetSize);
+    
     timers.totalCalculationTime.stopTimer();
-
     nlohmann::json result = Orchestrator::buildOutput(appData, *solution.get(), *data.get(), timers);
     std::ofstream outputFile;
     outputFile.open(appData.outputFile);

--- a/src/mpi_find_approximation_set.cpp
+++ b/src/mpi_find_approximation_set.cpp
@@ -44,7 +44,7 @@ void randGreedi(
     
     unsigned int sendDataSize = 0;
     std::vector<int> receivingDataSizesBuffer(appData.worldSize, 0);
-    std::vector<double> sendBuffer;
+    std::vector<float> sendBuffer;
     timers.totalCalculationTime.startTimer();
     if (appData.worldRank != 0) {
         
@@ -65,7 +65,7 @@ void randGreedi(
     timers.communicationTime.stopTimer();
     
     timers.bufferEncodingTime.startTimer();
-    std::vector<double> receiveBuffer;
+    std::vector<float> receiveBuffer;
     std::vector<int> displacements;
     if (appData.worldRank == 0) {
         BufferBuilder::buildReceiveBuffer(receivingDataSizesBuffer, receiveBuffer);
@@ -77,11 +77,11 @@ void randGreedi(
     MPI_Gatherv(
         sendBuffer.data(),
         sendBuffer.size(), 
-        MPI_DOUBLE, 
+        MPI_FLOAT, 
         receiveBuffer.data(), 
         receivingDataSizesBuffer.data(), 
         displacements.data(),
-        MPI_DOUBLE, 
+        MPI_FLOAT, 
         0, 
         MPI_COMM_WORLD
     );

--- a/src/representative_subset_calculator/buffers/tests.h
+++ b/src/representative_subset_calculator/buffers/tests.h
@@ -68,7 +68,7 @@ static std::unique_ptr<SegmentedData> getSparseData() {
 TEST_CASE("Testing the get total send dense data method") {
     std::unique_ptr<SegmentedData> denseData(getDenseData());
 
-    std::vector<double> sendBuffer;
+    std::vector<float> sendBuffer;
     unsigned int totalSendData = BufferBuilder::buildSendBuffer(*denseData, *MOCK_SOLUTION.get(), sendBuffer);
     CHECK(totalSendData == (denseData->totalColumns() + 2) * MOCK_SOLUTION->size() + 1);
     CHECK(sendBuffer.size() == totalSendData);
@@ -77,7 +77,7 @@ TEST_CASE("Testing the get total send dense data method") {
 TEST_CASE("Testing the get total send sparse data method") {
     std::unique_ptr<SegmentedData> sparseData(getSparseData());
 
-    std::vector<double> sendBuffer;
+    std::vector<float> sendBuffer;
     unsigned int totalSendData = BufferBuilder::buildSendBuffer(*sparseData, *MOCK_SOLUTION.get(), sendBuffer);
     CHECK(totalSendData == (sparseData->totalColumns() + 1) * MOCK_SOLUTION->size() + 1);
     CHECK(sendBuffer.size() == totalSendData);
@@ -86,7 +86,7 @@ TEST_CASE("Testing the get total send sparse data method") {
 TEST_CASE("Test building send buffers for") {
     std::unique_ptr<SegmentedData> data(getDenseData());
 
-    std::vector<double> sendBuffer;
+    std::vector<float> sendBuffer;
     unsigned int totalSendData = BufferBuilder::buildSendBuffer(*data, *MOCK_SOLUTION.get(), sendBuffer);
 
     CHECK(sendBuffer.size() == totalSendData);
@@ -102,7 +102,7 @@ TEST_CASE("Test building send buffers for") {
 TEST_CASE("Getting solution from a buffer") {
     std::unique_ptr<SegmentedData> denseData(getDenseData());
 
-    std::vector<double> sendBuffer;
+    std::vector<float> sendBuffer;
     unsigned int totalSendData = BufferBuilder::buildSendBuffer(*denseData, *MOCK_SOLUTION.get(), sendBuffer);
     
     std::vector<int> displacements;

--- a/src/representative_subset_calculator/fast_representative_subset_calculator.h
+++ b/src/representative_subset_calculator/fast_representative_subset_calculator.h
@@ -5,17 +5,17 @@
 
 class FastSubsetCalculator : public SubsetCalculator {
     private:
-    const double epsilon;
+    const float epsilon;
 
-    static std::pair<size_t, double> getNextHighestScore(
-        const std::vector<double> &diagonals, 
+    static std::pair<size_t, float> getNextHighestScore(
+        const std::vector<float> &diagonals, 
         const std::unordered_set<size_t> &seen 
     ) {
         size_t bestRow = -1;
-        double highestScore = -1;
+        float highestScore = -1;
 
         for (size_t i = 0; i < diagonals.size(); i++) {
-            double score = std::log(diagonals[i]);
+            float score = std::log(diagonals[i]);
             if (seen.find(i) == seen.end() && score > highestScore) {
                 highestScore = score;
                 bestRow = i;
@@ -30,7 +30,7 @@ class FastSubsetCalculator : public SubsetCalculator {
     }
 
   public:
-    FastSubsetCalculator(const double epsilon) : epsilon(epsilon) {
+    FastSubsetCalculator(const float epsilon) : epsilon(epsilon) {
         if (this->epsilon < 0) {
             throw std::invalid_argument("Epsilon is less than 0.");
         }
@@ -44,9 +44,9 @@ class FastSubsetCalculator : public SubsetCalculator {
         std::unordered_set<size_t> seen;
 
         std::unique_ptr<NaiveKernelMatrix> kernelMatrix(NaiveKernelMatrix::from(data));
-        std::vector<double> diagonals = kernelMatrix->getDiagonals(); 
+        std::vector<float> diagonals = kernelMatrix->getDiagonals(); 
 
-        std::vector<std::vector<double>> c(data.totalRows(), std::vector<double>());
+        std::vector<std::vector<float>> c(data.totalRows(), std::vector<float>());
 
         auto bestScore = getNextHighestScore(diagonals, seen);
         size_t j = bestScore.first;
@@ -60,7 +60,7 @@ class FastSubsetCalculator : public SubsetCalculator {
                     continue;
                 }
                 
-                double e = (kernelMatrix->get(j, i) - KernelMatrix::getDotProduct(c[j], c[i])) / std::sqrt(diagonals[j]);
+                float e = (kernelMatrix->get(j, i) - KernelMatrix::getDotProduct(c[j], c[i])) / std::sqrt(diagonals[j]);
                 c[i].push_back(e);
                 diagonals[i] -= std::pow(e, 2);
             }

--- a/src/representative_subset_calculator/kernel_matrix/relevance_calculator.h
+++ b/src/representative_subset_calculator/kernel_matrix/relevance_calculator.h
@@ -3,7 +3,7 @@
 
 class RelevanceCalculator {
     public:
-    virtual double get(const size_t a, const size_t b) const = 0;
+    virtual float get(const size_t a, const size_t b) const = 0;
 };
 
 class NaiveRelevanceCalculator : public RelevanceCalculator {
@@ -13,7 +13,7 @@ class NaiveRelevanceCalculator : public RelevanceCalculator {
     public:
     NaiveRelevanceCalculator(const BaseData &data) : data(data) {}
 
-    double get(const size_t a, const size_t b) const {
+    float get(const size_t a, const size_t b) const {
         return this->data.getRow(a).dotProduct(this->data.getRow(b)) + static_cast<int>(a == b);
     }
 };

--- a/src/representative_subset_calculator/kernel_matrix/relevance_calculator_factory.h
+++ b/src/representative_subset_calculator/kernel_matrix/relevance_calculator_factory.h
@@ -34,7 +34,7 @@ class PerRowRelevanceCalculator {
     };
 
     public:
-    static double getScore(const DataRow &row, const RelevanceCalculatorFactory &factory) {
+    static float getScore(const DataRow &row, const RelevanceCalculatorFactory &factory) {
         DummyData data(row);
         return factory.build(data)->get(0, 0);
     }

--- a/src/representative_subset_calculator/kernel_matrix/tests.h
+++ b/src/representative_subset_calculator/kernel_matrix/tests.h
@@ -7,8 +7,8 @@ TEST_CASE("Kernel matracies are equivalent") {
 
     for (size_t j = 0; j < denseData->totalRows(); j++) {
         for (size_t i = 0; i < denseData->totalRows(); i++) {
-            double naiveValue = naiveMatrix->get(j, i);
-            double lazyValue = lazyMatrix->get(j, i);
+            float naiveValue = naiveMatrix->get(j, i);
+            float lazyValue = lazyMatrix->get(j, i);
             CHECK(naiveValue > lazyValue - LARGEST_ACCEPTABLE_ERROR);
             CHECK(naiveValue < lazyValue + LARGEST_ACCEPTABLE_ERROR);
         }

--- a/src/representative_subset_calculator/lazy_fast_representative_subset_calculator.h
+++ b/src/representative_subset_calculator/lazy_fast_representative_subset_calculator.h
@@ -7,22 +7,22 @@
 
 class LazyFastSubsetCalculator : public SubsetCalculator {
     private:
-    const double epsilon;
+    const float epsilon;
 
     struct HeapComparitor {
-        const std::vector<double> &diagonals;
-        HeapComparitor(const std::vector<double> &diagonals) : diagonals(diagonals) {}
+        const std::vector<float> &diagonals;
+        HeapComparitor(const std::vector<float> &diagonals) : diagonals(diagonals) {}
         bool operator()(size_t a, size_t b) {
             return std::log(diagonals[a]) < std::log(diagonals[b]);
         }
     };
 
-    static std::vector<double> getSlice(
-        const std::unordered_map<size_t, double> &row, 
+    static std::vector<float> getSlice(
+        const std::unordered_map<size_t, float> &row, 
         const MutableSubset* subset, 
         size_t count
     ) {
-        std::vector<double> res(count);
+        std::vector<float> res(count);
         for (size_t i = 0; i < count ; i++) {
             res[i] = row.at(subset->getRow(i));
         }
@@ -31,7 +31,7 @@ class LazyFastSubsetCalculator : public SubsetCalculator {
     }
 
     public:
-    LazyFastSubsetCalculator(const double epsilon) : epsilon(epsilon) {
+    LazyFastSubsetCalculator(const float epsilon) : epsilon(epsilon) {
         if (this->epsilon < 0) {
             throw std::invalid_argument("Epsilon is less than 0.");
         }
@@ -43,14 +43,16 @@ class LazyFastSubsetCalculator : public SubsetCalculator {
         const BaseData &data, 
         size_t k
     ) {
+        
         std::unordered_set<size_t> seen;
-        std::vector<std::unordered_map<size_t, double>> v(data.totalRows());
+        std::vector<std::unordered_map<size_t, float>> v(data.totalRows());
         std::vector<size_t> u(data.totalRows(), 0);
-
+        
         // Initialize kernel matrix 
         std::unique_ptr<LazyKernelMatrix> kernelMatrix(LazyKernelMatrix::from(data));
-        std::vector<double> diagonals = kernelMatrix->getDiagonals();
-
+        
+        std::vector<float> diagonals = kernelMatrix->getDiagonals();
+        
         // Initialize priority queue
         std::vector<size_t> priorityQueue;
         for (size_t index = 0; index < data.totalRows(); index++) {
@@ -59,27 +61,29 @@ class LazyFastSubsetCalculator : public SubsetCalculator {
 
         HeapComparitor comparitor(diagonals);
         std::make_heap(priorityQueue.begin(), priorityQueue.end(), comparitor);
+        
         while (consumer->size() < k) {
             size_t i = priorityQueue.front();
             std::pop_heap(priorityQueue.begin(),priorityQueue.end(), comparitor); 
             priorityQueue.pop_back();
-
+            
             // update row
             for (size_t t = u[i]; t < consumer->size(); t++) {
+
                 size_t j_t = consumer->getRow(t); 
-                double dotProduct = KernelMatrix::getDotProduct(this->getSlice(v[i], consumer.get(), t), this->getSlice(v[j_t], consumer.get(), t));
-                v[i].insert({j_t, (kernelMatrix->get(i, j_t) - dotProduct) / std::sqrt(diagonals[j_t])});
+                float dotProduct = KernelMatrix::getDotProduct(this->getSlice(v[i], consumer.get(), t), this->getSlice(v[j_t], consumer.get(), t));                
+                v[i].insert({j_t, (kernelMatrix->get(i, j_t) - dotProduct) / std::sqrt(diagonals[j_t])});                
                 diagonals[i] -= std::pow(v[i][j_t], 2);
             }
-
+            
             u[i] = consumer->size();
             
             // To ensure "Numerical stability" ¯\_(ツ)_/¯
             if (diagonals[i] < this->epsilon) 
                 break;
             
-            double marginalGain = std::log(diagonals[i]);
-            double nextScore = std::log(diagonals[priorityQueue.front()]);
+            float marginalGain = std::log(diagonals[i]);
+            float nextScore = std::log(diagonals[priorityQueue.front()]);
 
             if (marginalGain >= nextScore || consumer->size() == data.totalRows() - 1) {
                 consumer->addRow(i, marginalGain);
@@ -88,7 +92,6 @@ class LazyFastSubsetCalculator : public SubsetCalculator {
                 std::push_heap(priorityQueue.begin(), priorityQueue.end(), comparitor);
             }
         }
-
         return MutableSubset::upcast(move(consumer));
     }
 };

--- a/src/representative_subset_calculator/lazy_representative_subset_calculator.h
+++ b/src/representative_subset_calculator/lazy_representative_subset_calculator.h
@@ -11,7 +11,7 @@ class LazySubsetCalculator : public SubsetCalculator {
     private:
 
     struct HeapComparitor {
-        bool operator()(const std::pair<size_t, double> a, const std::pair<size_t, double> b) {
+        bool operator()(const std::pair<size_t, float> a, const std::pair<size_t, float> b) {
             return a.second < b.second;
         }
     };
@@ -24,7 +24,7 @@ class LazySubsetCalculator : public SubsetCalculator {
         const BaseData &data, 
         size_t k
     ) {
-        std::vector<std::pair<size_t, double>> heap;
+        std::vector<std::pair<size_t, float>> heap;
         for (size_t index = 0; index < data.totalRows(); index++) {
             // TODO: Use the kernel matrix here, keep diagonals as state
             MutableSimilarityMatrix matrix(data.getRow(index));
@@ -36,7 +36,7 @@ class LazySubsetCalculator : public SubsetCalculator {
 
         MutableSimilarityMatrix matrix;
 
-        double currentScore = 0;
+        float currentScore = 0;
 
         while (consumer->size() < k) {
             auto top = heap.front();
@@ -46,12 +46,12 @@ class LazySubsetCalculator : public SubsetCalculator {
             // TODO: Use the kernel matrix here, keep diagonals as state
             MutableSimilarityMatrix tempMatrix(matrix);
             tempMatrix.addRow(data.getRow(top.first));
-            double marginal = tempMatrix.getCoverage();
+            float marginal = tempMatrix.getCoverage();
 
             auto nextElement = heap.front();
 
             if (marginal >= nextElement.second) {
-                double marginalGain = marginal - currentScore;
+                float marginalGain = marginal - currentScore;
                 consumer->addRow(top.first, marginalGain);
                 matrix.addRow(data.getRow(top.first));
                 currentScore = marginal;

--- a/src/representative_subset_calculator/naive_representative_subset_calculator.h
+++ b/src/representative_subset_calculator/naive_representative_subset_calculator.h
@@ -20,10 +20,10 @@ class NaiveSubsetCalculator : public SubsetCalculator {
         MutableSimilarityMatrix matrix; 
         std::set<size_t> seen;
 
-        double currentScore = 0;
+        float currentScore = 0;
 
         for (size_t seed = 0; seed < k; seed++) {
-            std::vector<double> marginals(data.totalRows());
+            std::vector<float> marginals(data.totalRows());
 
             #pragma omp parallel for 
             for (size_t index = 0; index < data.totalRows(); index++) {
@@ -33,8 +33,8 @@ class NaiveSubsetCalculator : public SubsetCalculator {
                 marginals[index] = tempMatrix.getCoverage();
             }
 
-            double highestMarginal = -std::numeric_limits<double>::max();
-            double changeInMarginal = 0;
+            float highestMarginal = -std::numeric_limits<float>::max();
+            float changeInMarginal = 0;
             size_t bestRow = -1;
             for (size_t index = 0; index < data.totalRows(); index++) {
                 if (seen.find(index) != seen.end()) {
@@ -53,7 +53,7 @@ class NaiveSubsetCalculator : public SubsetCalculator {
                 return MutableSubset::upcast(move(consumer));
             }
 
-            double marginalGain = highestMarginal - currentScore;
+            float marginalGain = highestMarginal - currentScore;
             consumer->addRow(bestRow, marginalGain);
             matrix.addRow(data.getRow(bestRow));
             seen.insert(bestRow);

--- a/src/representative_subset_calculator/orchestrator/orchestrator.h
+++ b/src/representative_subset_calculator/orchestrator/orchestrator.h
@@ -8,7 +8,7 @@
 #include <optional>
 
 const static std::string EMPTY_STRING = "\n";
-const static double DEFAULT_GENERATED_SPARSITY = -1;
+const static float DEFAULT_GENERATED_SPARSITY = -1;
 
 struct loadInput {
     std::string inputFile = EMPTY_STRING;
@@ -19,7 +19,7 @@ struct generateInput {
     int generationStrategy = 0;
     size_t genRows = 0;
     size_t genCols = 0;
-    double sparsity = DEFAULT_GENERATED_SPARSITY;
+    float sparsity = DEFAULT_GENERATED_SPARSITY;
     long unsigned int seed = -1;
 } typedef GenerateInput;
 
@@ -29,12 +29,12 @@ struct appData{
     unsigned int adjacencyListColumnCount = 0;
     bool binaryInput = false;
     bool normalizeInput = false;
-    double epsilon = -1;
+    float epsilon = -1;
     unsigned int algorithm;
     unsigned int distributedAlgorithm = 2;
-    double distributedEpsilon = 0.13;
+    float distributedEpsilon = 0.13;
     unsigned int threeSieveT;
-    double alpha = 1;
+    float alpha = 1;
 
     int worldSize = 1;
     int worldRank = 0;

--- a/src/representative_subset_calculator/representative_subset.h
+++ b/src/representative_subset_calculator/representative_subset.h
@@ -3,20 +3,20 @@
 
 class Subset {
     public:
-    virtual double getScore() const = 0;
+    virtual float getScore() const = 0;
     virtual size_t getRow(const size_t index) const = 0;
     virtual size_t size() const = 0;
     virtual nlohmann::json toJson() const = 0;
     virtual const size_t* begin() const = 0;
     virtual const size_t* end() const = 0;
 
-    static std::unique_ptr<Subset> of(const std::vector<size_t> &rows, const double score);
+    static std::unique_ptr<Subset> of(const std::vector<size_t> &rows, const float score);
     static std::unique_ptr<Subset> empty();
 };
 
 class MutableSubset : public Subset {
     public:
-    virtual void addRow(const size_t row, const double marginalGain) = 0;
+    virtual void addRow(const size_t row, const float marginalGain) = 0;
     virtual void finalize() = 0;
 
     static std::unique_ptr<Subset> upcast(std::unique_ptr<MutableSubset> mutableSubset) {
@@ -27,19 +27,19 @@ class MutableSubset : public Subset {
 
 class NaiveMutableSubset : public MutableSubset {
     private:
-    double score;
+    float score;
     std::vector<size_t> rows;
 
     public:
     NaiveMutableSubset() : score(0), rows(std::vector<size_t>()) {}
-    NaiveMutableSubset(const std::vector<size_t> &rows, const double score) : rows(rows), score(score) {}
+    NaiveMutableSubset(const std::vector<size_t> &rows, const float score) : rows(rows), score(score) {}
 
-    void addRow(const size_t row, const double marginalGain) {
+    void addRow(const size_t row, const float marginalGain) {
         this->rows.push_back(row);
         this->score += marginalGain;
     }
 
-    double getScore() const {
+    float getScore() const {
         return score;
     }
 
@@ -77,7 +77,7 @@ class NaiveMutableSubset : public MutableSubset {
 
 std::unique_ptr<Subset> Subset::of(
     const std::vector<size_t> &rows, 
-    const double score
+    const float score
 ) {
     Subset* subset = dynamic_cast<Subset*>(new NaiveMutableSubset(rows, score));
     return std::unique_ptr<Subset>(subset);

--- a/src/representative_subset_calculator/similarity_matrix/similarity_matrix.h
+++ b/src/representative_subset_calculator/similarity_matrix/similarity_matrix.h
@@ -7,13 +7,13 @@
 
 class SimilarityMatrix {
     public:
-    virtual double getCoverage() const = 0; 
+    virtual float getCoverage() const = 0; 
 };
 
 class MutableSimilarityMatrix : public SimilarityMatrix {
     private:
     std::vector<const DataRow*> baseRows;
-    std::vector<std::vector<double>> transposeMatrix;
+    std::vector<std::vector<float>> transposeMatrix;
 
     public:
     MutableSimilarityMatrix() {}
@@ -32,12 +32,12 @@ class MutableSimilarityMatrix : public SimilarityMatrix {
         return this->baseRows;
     }
 
-    const std::vector<std::vector<double>> &getTranspose() const {
+    const std::vector<std::vector<float>> &getTranspose() const {
         return this->transposeMatrix;
     }
 
     void addRow(const DataRow &newRow) {
-        this->transposeMatrix.push_back(std::vector<double>(this->transposeMatrix.size() + 1));
+        this->transposeMatrix.push_back(std::vector<float>(this->transposeMatrix.size() + 1));
         for (size_t i = 0; i < this->baseRows.size(); i++) {
             this->transposeMatrix[i].push_back(this->baseRows[i]->dotProduct(newRow));
             this->transposeMatrix.back()[i] = this->transposeMatrix[i].back();
@@ -47,15 +47,15 @@ class MutableSimilarityMatrix : public SimilarityMatrix {
         this->transposeMatrix.back().back() = newRow.dotProduct(newRow) + 1;
     }
 
-    double getCoverage() const {
-        Eigen::MatrixXd kernelMatrix(this->transposeMatrix.size(), this->transposeMatrix.size());
+    float getCoverage() const {
+        Eigen::MatrixXf kernelMatrix(this->transposeMatrix.size(), this->transposeMatrix.size());
         for (int i = 0; i < this->transposeMatrix.size(); i++) {
-            kernelMatrix.row(i) = Eigen::VectorXd::Map(this->transposeMatrix[i].data(), this->transposeMatrix[i].size());
+            kernelMatrix.row(i) = Eigen::VectorXf::Map(this->transposeMatrix[i].data(), this->transposeMatrix[i].size());
         }
 
-        Eigen::MatrixXd diagonal(kernelMatrix.llt().matrixL());
+        Eigen::MatrixXf diagonal(kernelMatrix.llt().matrixL());
 
-        double res = 0;
+        float res = 0;
         for (size_t index = 0; index < diagonal.rows(); index++) {
             res += std::log(diagonal(index,index));
         }

--- a/src/representative_subset_calculator/similarity_matrix/tests.h
+++ b/src/representative_subset_calculator/similarity_matrix/tests.h
@@ -3,12 +3,12 @@
 
 TEST_CASE("Testing matrix mutability") {
     MutableSimilarityMatrix matrix;
-    double previousScore = -1;
+    float previousScore = -1;
     std::unique_ptr<FullyLoadedData> denseData(FullyLoadedData::load(DENSE_DATA));
 
     for (size_t j = 0; j < denseData->totalRows(); j++) {
         matrix.addRow(denseData->getRow(j));
-        double currentScore = matrix.getCoverage();
+        float currentScore = matrix.getCoverage();
         CHECK(previousScore <= currentScore);
         previousScore = currentScore;
     }

--- a/src/representative_subset_calculator/streaming/bucket.h
+++ b/src/representative_subset_calculator/streaming/bucket.h
@@ -6,29 +6,29 @@ class ThresholdBucket
     private:
     std::unique_ptr<MutableSubset> solution;
     std::unique_ptr<std::vector<const DataRow *>> solutionRows; 
-    std::unique_ptr<std::vector<double>> d; 
+    std::unique_ptr<std::vector<float>> d; 
     std::unique_ptr<std::vector<std::unique_ptr<DenseDataRow>>> b; 
 
-    double threshold;
+    float threshold;
     int k;
 
     public:
-    ThresholdBucket(const double threshold, const int k) 
+    ThresholdBucket(const float threshold, const int k) 
     : 
         threshold(threshold), 
         k(k), 
         solution(NaiveMutableSubset::makeNew()), 
         solutionRows(std::make_unique<std::vector<const DataRow *>>()),
-        d(std::make_unique<std::vector<double>>()),
+        d(std::make_unique<std::vector<float>>()),
         b(std::make_unique<std::vector<std::unique_ptr<DenseDataRow>>>())
     {}
 
     ThresholdBucket(
-        const double threshold, 
+        const float threshold, 
         const int k, 
         std::unique_ptr<MutableSubset> nextSolution,
         std::unique_ptr<std::vector<const DataRow *>> solutionRows,
-        std::unique_ptr<std::vector<double>> d,
+        std::unique_ptr<std::vector<float>> d,
         std::unique_ptr<std::vector<std::unique_ptr<DenseDataRow>>> b
     ) : 
         threshold(threshold), 
@@ -39,7 +39,7 @@ class ThresholdBucket
         b(move(b))
     {}
 
-    std::unique_ptr<ThresholdBucket> transferContents(const double newThreshold) {
+    std::unique_ptr<ThresholdBucket> transferContents(const float newThreshold) {
         return std::unique_ptr<ThresholdBucket>(
             new ThresholdBucket(
                 newThreshold, 
@@ -65,19 +65,19 @@ class ThresholdBucket
             return false;
         }
         
-        double d_i = std::sqrt(data.dotProduct(data));
+        float d_i = std::sqrt(data.dotProduct(data));
         std::unique_ptr<DenseDataRow> c_i(new DenseDataRow());
 
         for (size_t j = 0; j < this->solution->size(); j++) {
             if (!this->passesThreshold(std::log(std::pow(d_i, 2)))) {
                 return false;
             }
-            const double e_i = (data.dotProduct(*(solutionRows->at(j))) - c_i->dotProduct(*b->at(j))) / d->at(j);
+            const float e_i = (data.dotProduct(*(solutionRows->at(j))) - c_i->dotProduct(*b->at(j))) / d->at(j);
             c_i->push_back(e_i);
             d_i = std::sqrt(std::pow(d_i, 2) - std::pow(e_i, 2));
         }
 
-        const double marginal = std::log(std::pow(d_i, 2));
+        const float marginal = std::log(std::pow(d_i, 2));
         if (this->passesThreshold(marginal)) {
             this->solution->addRow(rowIndex, marginal);
             this->solutionRows->push_back(&data);
@@ -90,7 +90,7 @@ class ThresholdBucket
     }
 
     private:
-    bool passesThreshold(double marginalGain) {
+    bool passesThreshold(float marginalGain) {
         return marginalGain >= (((this->threshold / 2) - this->solution->getScore()) / (this->k - this->solution->size()));
     }
 };

--- a/src/representative_subset_calculator/streaming/candidate_consumer.h
+++ b/src/representative_subset_calculator/streaming/candidate_consumer.h
@@ -14,7 +14,7 @@ class NaiveCandidateConsumer : public CandidateConsumer {
 
     std::unordered_set<unsigned int> seenFirstElement;
     std::unordered_set<unsigned int> firstGlobalRows;
-    double bestMarginal;
+    float bestMarginal;
 
     public: 
     static std::unique_ptr<NaiveCandidateConsumer> from(
@@ -62,7 +62,7 @@ class NaiveCandidateConsumer : public CandidateConsumer {
     private:
     void tryToGetFirstMarginals(SynchronousQueue<std::unique_ptr<CandidateSeed>> &seedQueue) {
         std::vector<std::unique_ptr<CandidateSeed>> pulledFromQueue(move(seedQueue.emptyQueueIntoVector()));
-        std::vector<std::pair<unsigned int, double>> rowToMarginal(pulledFromQueue.size(), std::make_pair(0,0));
+        std::vector<std::pair<unsigned int, float>> rowToMarginal(pulledFromQueue.size(), std::make_pair(0,0));
         
         #pragma omp parallel for
         for (size_t i = 0; i < pulledFromQueue.size(); i++) {
@@ -71,7 +71,7 @@ class NaiveCandidateConsumer : public CandidateConsumer {
             // TODO: Only process the first seed from each sender
             if (this->firstGlobalRows.find(seed->getRow()) == this->firstGlobalRows.end()) {
                 const DataRow & row(seed->getData());
-                double score = std::log(std::sqrt(PerRowRelevanceCalculator::getScore(row, *calcFactory))) * 2;
+                float score = std::log(std::sqrt(PerRowRelevanceCalculator::getScore(row, *calcFactory))) * 2;
                 rowToMarginal[i].second = score;
             }
 
@@ -99,7 +99,7 @@ class NaiveCandidateConsumer : public CandidateConsumer {
         seedQueue.emptyVectorIntoQueue(move(pulledFromQueue));
     }
 
-    double getDeltaZero() {
+    float getDeltaZero() {
         return bestMarginal;
     }
 };

--- a/src/representative_subset_calculator/streaming/communication_constants.h
+++ b/src/representative_subset_calculator/streaming/communication_constants.h
@@ -12,7 +12,7 @@ class CommunicationConstants {
         return 0;
     }
 
-    static double endOfSendTag() {
+    static float endOfSendTag() {
         return -1;
     }
 };

--- a/src/representative_subset_calculator/streaming/mpi_streaming_classes.h
+++ b/src/representative_subset_calculator/streaming/mpi_streaming_classes.h
@@ -5,15 +5,15 @@
 
 class MpiSendRequest {
     private:
-    const std::vector<double> rowToSend;
+    const std::vector<float> rowToSend;
     MPI_Request request;
 
     public:
-    MpiSendRequest(std::vector<double> rowToSend) 
+    MpiSendRequest(std::vector<float> rowToSend) 
     : rowToSend(move(rowToSend)) {}
 
     void isend(const unsigned int tag) {
-        MPI_Isend(rowToSend.data(), rowToSend.size(), MPI_DOUBLE, 0, tag, MPI_COMM_WORLD, &request);
+        MPI_Isend(rowToSend.data(), rowToSend.size(), MPI_FLOAT, 0, tag, MPI_COMM_WORLD, &request);
     }
 
     void waitForISend() {
@@ -27,7 +27,7 @@ class MpiRankBuffer : public RankBuffer {
     const unsigned int rank;
     const DataRowFactory &factory;
 
-    std::vector<double> buffer;
+    std::vector<float> buffer;
     MPI_Request request;
     bool isStillReceiving;
     std::unique_ptr<MutableSubset> rankSolution;
@@ -78,7 +78,7 @@ class MpiRankBuffer : public RankBuffer {
         return this->rank;
     }
 
-    double getLocalSolutionScore() const {
+    float getLocalSolutionScore() const {
         return this->rankSolution->getScore();
     }
 
@@ -90,7 +90,7 @@ class MpiRankBuffer : public RankBuffer {
     void readyForNextReceive() {
         MPI_Irecv(
             buffer.data(), buffer.size(), 
-            MPI_DOUBLE, rank, MPI_ANY_TAG, 
+            MPI_FLOAT, rank, MPI_ANY_TAG, 
             MPI_COMM_WORLD, &request
         );
     }
@@ -105,8 +105,8 @@ class MpiRankBuffer : public RankBuffer {
         *endOfData = 0;
 
         const size_t globalRowIndex = static_cast<size_t>(*(endOfData - 1));
-        const double localMarginalGain = *(endOfData - 2);
-        std::vector<double> data(this->buffer.begin(), endOfData - 2);
+        const float localMarginalGain = *(endOfData - 2);
+        std::vector<float> data(this->buffer.begin(), endOfData - 2);
         this->rankSolution->addRow(globalRowIndex, localMarginalGain);
         return new CandidateSeed(globalRowIndex, this->factory.getFromBinary(move(data)), this->rank);
     }

--- a/src/representative_subset_calculator/streaming/rank_buffer.h
+++ b/src/representative_subset_calculator/streaming/rank_buffer.h
@@ -5,6 +5,6 @@ class RankBuffer {
     virtual CandidateSeed* askForData() = 0;
     virtual bool stillReceiving() = 0;
     virtual unsigned int getRank() const = 0;
-    virtual double getLocalSolutionScore() const = 0;
+    virtual float getLocalSolutionScore() const = 0;
     virtual std::unique_ptr<Subset> getLocalSolutionDestroyBuffer() = 0;
 };

--- a/src/representative_subset_calculator/streaming/receiver_interface.h
+++ b/src/representative_subset_calculator/streaming/receiver_interface.h
@@ -46,10 +46,10 @@ class NaiveReceiver : public Receiver {
     }
 
     std::unique_ptr<Subset> getBestReceivedSolution() {
-        double bestSolution = 0;
+        float bestSolution = 0;
         size_t bestRank = -1;
         for (size_t i = 0; i < this->buffers.size(); i++) {
-            const double rankScore = this->buffers[i]->getLocalSolutionScore();
+            const float rankScore = this->buffers[i]->getLocalSolutionScore();
             std::cout << "rank " << i << " had score of " << rankScore << std::endl;
             if (rankScore > bestSolution) {
                 bestRank = i;

--- a/src/representative_subset_calculator/streaming/streaming_subset.h
+++ b/src/representative_subset_calculator/streaming/streaming_subset.h
@@ -27,7 +27,7 @@ class StreamingSubset : public MutableSubset {
         timers.firstSeedTime.startTimer();
     }
 
-    double getScore() const {
+    float getScore() const {
         return base->getScore();
     }
 
@@ -66,11 +66,11 @@ class StreamingSubset : public MutableSubset {
         this->timers.communicationTime.stopTimer();
     }
 
-    void addRow(const size_t row, const double marginalGain) {
+    void addRow(const size_t row, const float marginalGain) {
         this->base->addRow(row, marginalGain);
 
         ToBinaryVisitor visitor;
-        std::vector<double> rowToSend(move(this->data.getRow(row).visit(visitor)));
+        std::vector<float> rowToSend(move(this->data.getRow(row).visit(visitor)));
 
         // second to last value should be the marginal gain of this element for the local solution
         rowToSend.push_back(marginalGain);

--- a/src/representative_subset_calculator/streaming/tests.h
+++ b/src/representative_subset_calculator/streaming/tests.h
@@ -9,11 +9,11 @@
 #include "receiver_interface.h"
 #include "greedy_streamer.h"
 
-static const double EVERYTHING_ALLOWED_THRESHOLD = 0.0000001;
-static const double EVERYTHING_DISALLOWED_THRESHOLD = 0.999;
+static const float EVERYTHING_ALLOWED_THRESHOLD = 0.0000001;
+static const float EVERYTHING_DISALLOWED_THRESHOLD = 0.999;
 static const int K = 3;
 static const int T = 1;
-static double EPSILON = 0.5;
+static float EPSILON = 0.5;
 
 std::unique_ptr<CandidateSeed> buildSeed(const size_t row, const unsigned int rank) {
     return std::unique_ptr<CandidateSeed>(
@@ -32,7 +32,7 @@ std::unique_ptr<CandidateSeed> buildSeed() {
     return buildSeed(row, rank);
 }
 
-std::unique_ptr<BucketTitrator> getTitrator(unsigned int numThreads, double eps, unsigned int k) {
+std::unique_ptr<BucketTitrator> getTitrator(unsigned int numThreads, float eps, unsigned int k) {
     return std::unique_ptr<BucketTitrator>(new SieveStreamingBucketTitrator(numThreads, eps, k));
 }
 
@@ -118,7 +118,7 @@ class FakeRankBuffer : public RankBuffer {
         return this->rank;
     }
 
-    double getLocalSolutionScore() const {
+    float getLocalSolutionScore() const {
         return this->rankSolution->getScore();
     }
 

--- a/src/representative_subset_calculator/tests.h
+++ b/src/representative_subset_calculator/tests.h
@@ -15,7 +15,7 @@
 #include "streaming/tests.h"
 
 static const size_t k = DENSE_DATA.size();
-static const double epsilon = 0.01;
+static const float epsilon = 0.01;
 
 static std::unique_ptr<Subset> testCalculator(SubsetCalculator *calculator) {
     std::unique_ptr<FullyLoadedData> data(FullyLoadedData::load(DENSE_DATA));

--- a/src/tests.cpp
+++ b/src/tests.cpp
@@ -2,7 +2,7 @@
 #include <doctest/doctest.h>
 #include "representative_subset_calculator/streaming/communication_constants.h"
 
-static const std::vector<std::vector<double>> DENSE_DATA = {
+static const std::vector<std::vector<float>> DENSE_DATA = {
     {4,17,20,1,4,21},
     {5,7,31,45,3,24},
     {2.63212,5.12566,73,15,15,4},
@@ -11,7 +11,7 @@ static const std::vector<std::vector<double>> DENSE_DATA = {
     {6,31,54,3.5,23,57}
 };
 
-static const std::vector<std::vector<double>> SPARSE_DATA = {
+static const std::vector<std::vector<float>> SPARSE_DATA = {
     {0, 1, 4.2},
     {0, 2, 32},
     {0, 4, 1.23},
@@ -39,11 +39,11 @@ size_t totalColumns() {
 
 static const size_t SPARSE_DATA_TOTAL_COLUMNS = totalColumns();
 
-std::vector<std::map<size_t, double>> toMap() {
-    std::vector<std::map<size_t, double>> res;
+std::vector<std::map<size_t, float>> toMap() {
+    std::vector<std::map<size_t, float>> res;
     for (const auto & r : SPARSE_DATA) {
         if (res.size() <= r[0]) {
-            res.push_back(std::map<size_t, double>());
+            res.push_back(std::map<size_t, float>());
         }
 
         res.back().insert({r[1], r[2]});
@@ -52,10 +52,10 @@ std::vector<std::map<size_t, double>> toMap() {
     return res;
 };
 
-static const std::vector<std::map<size_t, double>> SPARSE_DATA_AS_MAP = toMap();
+static const std::vector<std::map<size_t, float>> SPARSE_DATA_AS_MAP = toMap();
 
 // Do to rounding errors, these results may not always be exactly equivalent
-static const double LARGEST_ACCEPTABLE_ERROR = 0.00000001;
+static const float LARGEST_ACCEPTABLE_ERROR = 0.001;
 
 #include "data_tools/tests.h"
 


### PR DESCRIPTION
"""
Decided to use float instead of double. We don't really need double precision. Aside from the double to float refactor here are notable changes:
- Used MatrixXf and VectorXf in place of MatrixXd and VectorXd for similarity matrix
- MPI_FLOAT instead of MPI_DOUBLE for communication calls
- Changed LARGEST_ACCEPTABLE_ERROR = 0.00000001 to LARGEST_ACCEPTABLE_ERROR = 0.001 to bring down precision --> TEST CASES PASS
"""
Reet