### PR TITLE
Consistent utility value across streaming and greedy

### DIFF
--- a/src/create_user_file.cpp
+++ b/src/create_user_file.cpp
@@ -371,7 +371,7 @@ int main(int argc, char** argv) {
                 score += matrix->get(cu_i, pu_j);
             }
             ru.insert({cu_i, score});
-            magnitude += std::pow(score, 2);
+            magnitude += 1;
         }
 
         magnitude = std::sqrt(magnitude);

--- a/src/representative_subset_calculator/fast_representative_subset_calculator.h
+++ b/src/representative_subset_calculator/fast_representative_subset_calculator.h
@@ -62,7 +62,7 @@ class FastSubsetCalculator : public SubsetCalculator {
         SPDLOG_TRACE("first seed is {0:d} of score {1:f}", bestScore.first, bestScore.second);
         size_t j = bestScore.first;
         seen.insert(j);
-        consumer->addRow(j, bestScore.second);
+        consumer->addRow(j, std::log(bestScore.second));
 
         while (consumer->size() < k) {
             #pragma omp parallel for 

--- a/src/representative_subset_calculator/fast_representative_subset_calculator.h
+++ b/src/representative_subset_calculator/fast_representative_subset_calculator.h
@@ -87,7 +87,7 @@ class FastSubsetCalculator : public SubsetCalculator {
 
             j = bestScore.first;
             seen.insert(j);
-            consumer->addRow(j, bestScore.second);
+            consumer->addRow(j, std::log(bestScore.second));
         }
     
         return MutableSubset::upcast(std::move(consumer));

--- a/src/representative_subset_calculator/lazy_fast_representative_subset_calculator.h
+++ b/src/representative_subset_calculator/lazy_fast_representative_subset_calculator.h
@@ -110,7 +110,7 @@ class LazyFastSubsetCalculator : public SubsetCalculator {
                 }
 
                 SPDLOG_TRACE("added next row {0:d} of score {1:f}", i, marginalGain);
-                consumer->addRow(i, marginalGain);
+                consumer->addRow(i, std::log(marginalGain));
                 in_subset.push_back(i);
             } else {
                 priorityQueue.push_back(i);

--- a/src/representative_subset_calculator/orchestrator/app_data.h
+++ b/src/representative_subset_calculator/orchestrator/app_data.h
@@ -36,7 +36,6 @@ struct AppData{
     bool stopEarly = false;
     bool loadWhileStreaming = false;
     bool sendAllToReceiver = false;
-    bool doNotNormalizeOnLoad = false;
     
     // user mode config
     std::string userModeFile = NO_FILE_DEFAULT;

--- a/src/representative_subset_calculator/orchestrator/orchestrator.h
+++ b/src/representative_subset_calculator/orchestrator/orchestrator.h
@@ -49,7 +49,6 @@ class Orchestrator {
         app.add_flag("--stopEarly", appData.stopEarly, "Used excusevly during streaming to stop the execution of the program early. If you use this in conjuntion with randgreedi, you will lose your approximation guarantee");
         app.add_option("-u,--userModeFile", appData.userModeFile, "Path to user mode data. Only set this if you are processing a dataset for a set of users.");
         app.add_option("--userModeTheta", appData.theta, "Only used during user mode. Sets the ratio of relevance to diveristy, where a value of 0.7 is a 70\% focuse on relevance.");
-        app.add_flag("--doNotNormalizeOnLoad", appData.doNotNormalizeOnLoad, "Normalize on load");
     
         CLI::App *loadInput = app.add_subcommand("loadInput", "loads the requested input from the provided path");
         CLI::App *genInput = app.add_subcommand("generateInput", "generates synthetic data");
@@ -202,7 +201,7 @@ class Orchestrator {
     }
 
     static std::unique_ptr<DataRowFactory> getDataRowFactory(const AppData& appData) {
-        return getDataRowFactory(appData.adjacencyListColumnCount, !appData.doNotNormalizeOnLoad);
+        return getDataRowFactory(appData.adjacencyListColumnCount, appData.userModeFile != NO_FILE_DEFAULT);
     }
 
     static std::unique_ptr<DataRowFactory> getDataRowFactory(

--- a/src/representative_subset_calculator/streaming/bucket.h
+++ b/src/representative_subset_calculator/streaming/bucket.h
@@ -79,7 +79,7 @@ class ThresholdBucket
         }
         
         // TODO: Verify the correctness of the +1 here. This might not be right.
-        float d_i = std::sqrt(data.dotProduct(data) + 1);
+        float d_i = std::sqrt(data.dotProduct(data));
         std::unique_ptr<DenseDataRow> c_i(new DenseDataRow());
 
         for (size_t j = 0; j < this->solution->size(); j++) {

--- a/src/single_machine_greedy_find_approximation_set.cpp
+++ b/src/single_machine_greedy_find_approximation_set.cpp
@@ -78,7 +78,7 @@ int main(int argc, char** argv) {
 
     timers.totalCalculationTime.stopTimer();
     auto memUsage = getPeakRSS()- baseline;
-    spdlog::info("mem usage of %d", memUsage);
+    spdlog::info("mem usage of {0:d}", memUsage);
     nlohmann::json result = Orchestrator::buildOutput(appData, solutions, *data.get(), timers);
     std::ofstream outputFile;
     outputFile.open(appData.outputFile);

--- a/src/single_machine_streaming_find_approximation_set.cpp
+++ b/src/single_machine_streaming_find_approximation_set.cpp
@@ -166,7 +166,7 @@ std::pair<std::unique_ptr<Subset>, size_t> loadThenCalculate(
     size_t memUsage = getPeakRSS()- baseline;
     
     timers.totalCalculationTime.stopTimer();
-
+    spdlog::info("mem usage of {0:d}", memUsage);
     std::unique_ptr<Subset> solution(titrator->getBestSolutionDestroyTitrator());
     return std::make_pair(std::move(solution), memUsage);
 }


### PR DESCRIPTION
Standalone greedy and streaming needs to use non-normalized data by default, no `std::log()` in their internal calculations, but stored marginals that get added will always be `std::log(di ^ 2)`. 

TODO::
1. Maybe flip the normalization flag so that only user-mode uses `--normalizeOnLoad`
2. Fix tests so that the solvers can handle non-normalized data. 